### PR TITLE
Fix garbled verb in the bridge three-tools sentence

### DIFF
--- a/content/06.bridge.md
+++ b/content/06.bridge.md
@@ -102,7 +102,7 @@ $$
 w_{ij}(c)\propto K\!\big(\phi(c),\phi(c_i)\big)\cdot \mathbf{1}\!\big[(i,j)\in S(c)\big].
 $$
 
-Adaptivity across estimation and inference are governed defined by three tools that can be applied independently:
+Adaptivity across estimation and inference is governed by three tools that can be applied independently:
 1) **Information** via $S(c)$ (what context is exposed),  
 2) **Inductive bias** via $\mathcal{R}(\theta;c)$ (how parameters may vary),  
 3) **Compute** via warm-starts/caching/steps (how aggressively we solve Eq. {@eq:unified} at test time).


### PR DESCRIPTION
One-line grammar fix in content/06.bridge.md, noticed while reviewing #100 but out of scope there.

Before:
> Adaptivity across estimation and inference are governed defined by three tools that can be applied independently:

After:
> Adaptivity across estimation and inference is governed by three tools that can be applied independently:

Two errors in the same clause: a leftover "defined" from an earlier revision, and a plural verb on the singular subject "Adaptivity". No content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)